### PR TITLE
ignore utf-8 BOM

### DIFF
--- a/iniflags.go
+++ b/iniflags.go
@@ -257,7 +257,7 @@ func getArgsFromConfig(configPath string) (args []flagArg, ok bool) {
 		}
 
 		/* ignore utf-8 BOM */
-		if len(line) > 3 && line[0] == '\xef' {
+		if len(line) >= 3 && line[0] == '\xef' {
 			line = line[3:]
 		}
 

--- a/iniflags.go
+++ b/iniflags.go
@@ -255,6 +255,12 @@ func getArgsFromConfig(configPath string) (args []flagArg, ok bool) {
 			args = append(args, importArgs...)
 			continue
 		}
+
+        /* ignore utf-8 BOM */
+        if len(line) > 3 && line[0] == '\xef' {
+            line = line[3:]
+        }
+
 		if line == "" || line[0] == ';' || line[0] == '#' || line[0] == '[' {
 			continue
 		}

--- a/iniflags.go
+++ b/iniflags.go
@@ -256,10 +256,10 @@ func getArgsFromConfig(configPath string) (args []flagArg, ok bool) {
 			continue
 		}
 
-        /* ignore utf-8 BOM */
-        if len(line) > 3 && line[0] == '\xef' {
-            line = line[3:]
-        }
+		/* ignore utf-8 BOM */
+		if len(line) > 3 && line[0] == '\xef' {
+			line = line[3:]
+		}
 
 		if line == "" || line[0] == ';' || line[0] == '#' || line[0] == '[' {
 			continue


### PR DESCRIPTION
Parse configure file may be failed when the configure file contains the utf8 BOM (byte order mark), 

the utf-8 BOM "\ufffe" and "\ufeff" encode to utf-8 is "\xef\xbf\xbe" and "\xef\xbb\xbf".
the configure file must be printable, so we lazy to check first byte, if the first byte is '\xef' and we ignore the first 3 bytes. 