### PR TITLE
go 1.3.3 build failure

### DIFF
--- a/iniflags.go
+++ b/iniflags.go
@@ -137,7 +137,7 @@ func issueAllFlagChangeCallbacks() {
 }
 
 func sighupHandler(ch <-chan os.Signal) {
-	for range ch {
+	for _ = range ch {
 		updateConfig()
 	}
 }


### PR DESCRIPTION
In older versions of go initflags does not build

```bash
# github.com/vharitonsky/iniflags
./iniflags.go:140: syntax error: unexpected range, expecting {
./iniflags.go:143: syntax error: unexpected }
```
This allows older versions