### PR TITLE
SetAllowUnknownFlags() and SetConfigUpdateInterval()

### DIFF
--- a/iniflags.go
+++ b/iniflags.go
@@ -410,3 +410,17 @@ func SetConfigFile(path string) {
 	}
 	*config = path
 }
+
+func SetAllowUnknownFlags(allowed bool) {
+	if parsed {
+		panic("iniflags: SetAllowUnknownFlags() must be called before Parse()")
+	}
+	*allowUnknownFlags = allowed
+}
+
+func SetConfigUpdateInterval(interval time.Duration) { 
+	if parsed {
+		panic("iniflags: SetConfigUpdateInterval() must be called before Parse()")
+	}
+	*configUpdateInterval = interval
+}

--- a/iniflags_test.go
+++ b/iniflags_test.go
@@ -3,6 +3,7 @@ package iniflags
 import (
 	"flag"
 	"testing"
+	"time"
 )
 
 func TestRemoveTrailingComments(t *testing.T) {
@@ -111,5 +112,23 @@ func TestSetConfigFile(t *testing.T) {
 	Parse()
 	if *x != "foobar" {
 		t.Fatalf("Unexpected x=[%s]. Expected [foobar]", *x)
+	}
+}
+
+func TestSetAllowUnknownFlags(t *testing.T) {
+	parsed = false
+	*allowUnknownFlags = false
+	SetAllowUnknownFlags(true)
+	if *allowUnknownFlags != true {
+		t.Fatal("SetAllowUnknownFlags failed to update global.")
+	}
+}
+
+func TestSetConfigUpdateInterval(t *testing.T) {
+	parsed = false
+	*configUpdateInterval = time.Second
+	SetConfigUpdateInterval(time.Minute)
+	if *configUpdateInterval != time.Minute {
+		t.Fatal("SetConfigUpdateInterval failed to update global.")
 	}
 }


### PR DESCRIPTION
Added exported functions and tests for setting the -allowUnknownFlags and -configUpdateInterval flags manually.  Fixes #13.