### PR TITLE
Allow default config file to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tags
+.DS_Store

--- a/iniflags.go
+++ b/iniflags.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	allowUnknownFlags    = flag.Bool("allowUnknownFlags", false, "Don't terminate the app if ini file contains unknown flags.")
+	allowMissingConfig   = flag.Bool("allowMissingConfig", false, "Don't terminate the app if the ini file cannot be read.")
 	config               = flag.String("config", "", "Path to ini config for using in go flags. May be relative to the current executable path.")
 	configUpdateInterval = flag.Duration("configUpdateInterval", 0, "Update interval for re-reading config file set via -config flag. Zero disables config file re-reading.")
 	dumpflags            = flag.Bool("dumpflags", false, "Dumps values for all flags defined in the app into stdout in ini-compatible syntax and terminates the app.")
@@ -235,9 +236,9 @@ func getArgsFromConfig(configPath string) (args []flagArg, ok bool) {
 		importStack = importStack[:len(importStack)-1]
 	}()
 
-	file := openConfigFile(configPath)
-	if file == nil {
-		return nil, false
+	file, err := openConfigFile(configPath)
+	if err != nil {
+		return nil, *allowMissingConfig
 	}
 	defer file.Close()
 	r := bufio.NewReader(file)
@@ -336,26 +337,26 @@ func getArgsFromConfig(configPath string) (args []flagArg, ok bool) {
 	return args, true
 }
 
-func openConfigFile(path string) io.ReadCloser {
+func openConfigFile(path string) (io.ReadCloser, error) {
 	if isHTTP(path) {
 		resp, err := http.Get(path)
 		if err != nil {
 			log.Printf("iniflags: cannot load config file at [%s]: [%s]\n", path, err)
-			return nil
+			return nil, err
 		}
 		if resp.StatusCode != http.StatusOK {
 			log.Printf("iniflags: unexpected http status code when obtaining config file [%s]: %d. Expected %d\n", path, resp.StatusCode, http.StatusOK)
-			return nil
+			return nil, err
 		}
-		return resp.Body
+		return resp.Body, nil
 	}
 
 	file, err := os.Open(path)
 	if err != nil {
 		log.Printf("iniflags: cannot open config file at [%s]: [%s]\n", path, err)
-		return nil
+		return nil, err
 	}
-	return file
+	return file, nil
 }
 
 func combinePath(basePath, relPath string) (string, bool) {
@@ -454,6 +455,13 @@ func SetConfigFile(path string) {
 		panic("iniflags: SetConfigFile() must be called before Parse()")
 	}
 	*config = path
+}
+
+func SetAllowMissingConfigFile(allowed bool) {
+	if parsed {
+		panic("iniflags: SetAllowUnknownFlags() must be called before Parse()")
+	}
+	*allowMissingConfig = allowed
 }
 
 func SetAllowUnknownFlags(allowed bool) {

--- a/iniflags.go
+++ b/iniflags.go
@@ -353,7 +353,9 @@ func openConfigFile(path string) (io.ReadCloser, error) {
 
 	file, err := os.Open(path)
 	if err != nil {
-		log.Printf("iniflags: cannot open config file at [%s]: [%s]\n", path, err)
+		if !(*allowMissingConfig) {
+			log.Printf("iniflags: cannot open config file at [%s]: [%s]\n", path, err)
+		}
 		return nil, err
 	}
 	return file, nil

--- a/iniflags_test.go
+++ b/iniflags_test.go
@@ -114,6 +114,15 @@ func TestSetConfigFile(t *testing.T) {
 	}
 }
 
+func TestSetAllowMissingConfigFile(t *testing.T) {
+	parsed = false
+	*allowMissingConfig = false
+	SetAllowMissingConfigFile(true)
+	if *allowMissingConfig != true {
+		t.Fatal("SetAllowUnknownFlags failed to update global.")
+	}
+}
+
 func TestSetAllowUnknownFlags(t *testing.T) {
 	parsed = false
 	*allowUnknownFlags = false


### PR DESCRIPTION
allow missing config file functionality allows the definition of a config file to try to load but does not halt program execution if the file does not exist.

Use case is:

```
	iniflags.SetConfigFile(".settings")
	iniflags.SetAllowMissingConfigFile(true)
	iniflags.Parse()
```

Where  `.settings` file may or may not exist in the program directory.
