### PR TITLE
Allow missing config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tags
+.DS_Store

--- a/iniflags_test.go
+++ b/iniflags_test.go
@@ -114,6 +114,15 @@ func TestSetConfigFile(t *testing.T) {
 	}
 }
 
+func TestSetAllowMissingConfigFile(t *testing.T) {
+	parsed = false
+	*allowMissingConfig = false
+	SetAllowMissingConfigFile(true)
+	if *allowMissingConfig != true {
+		t.Fatal("SetAllowUnknownFlags failed to update global.")
+	}
+}
+
 func TestSetAllowUnknownFlags(t *testing.T) {
 	parsed = false
 	*allowUnknownFlags = false


### PR DESCRIPTION
allow missing config file functionality 

allows the definition of a config file to try to load but does not halt program execution if the file does not exist.

Use case is:

	iniflags.SetConfigFile(".settings")
	iniflags.SetAllowMissingConfigFile(true)
	iniflags.Parse()
Where .settings file may or may not exist in the program directory.