### PR TITLE
Fix SetAllowMissingConfigFile error message

### DIFF
--- a/iniflags.go
+++ b/iniflags.go
@@ -502,7 +502,7 @@ func SetConfigFile(path string) {
 
 func SetAllowMissingConfigFile(allowed bool) {
 	if parsed {
-		panic("iniflags: SetAllowUnknownFlags() must be called before Parse()")
+		panic("iniflags: SetAllowMissingConfigFile() must be called before Parse()")
 	}
 	*allowMissingConfig = allowed
 }


### PR DESCRIPTION
The SetAllowMissingConfigFile error code looks like it was copied from SetAllowUnknownFlags without updating the error message.